### PR TITLE
Indicate OnePlus A6013 (6T) as not working

### DIFF
--- a/device_list.txt
+++ b/device_list.txt
@@ -1,6 +1,7 @@
 OnePlus_ONEPLUS A5000_OnePlus 5_Not Working
 OnePlus_ONEPLUS A5010_OnePlus 5T_Not Working
 OnePlus_ONEPLUS A6000_OnePlus 6_Not Working
+OnePlus_ONEPLUS A6013_ONEPLUS A6013_Not Working
 Google_Pixel 3 XL_Pixel 3 XL_Working
 OnePlus_GM1910_GM1910_Not Working
 HUAWEI_SNE-LX1_SNE-LX1_Working


### PR DESCRIPTION
Unsure if you want to leave the `A6013_ONEPLUS A6013` string as-is or change it to say OnePlus 6T, to be more clear.